### PR TITLE
Added checking imageview to prevent NPE on ParallaxScrollView

### DIFF
--- a/Parallax/src/net/appkraft/parallax/ParallaxScrollView.java
+++ b/Parallax/src/net/appkraft/parallax/ParallaxScrollView.java
@@ -204,7 +204,7 @@ public class ParallaxScrollView extends ScrollView {
 
 	public void setViewsBounds(double zoomRatio) {
 
-		if (mImageViewHeight == -1) {
+		if (mImageViewHeight == -1 && mImageView != null) {
 
 			mImageViewHeight = mImageView.getHeight();
 


### PR DESCRIPTION
To prevent causing NullPointerException while image resource is loading from network on activity start, add null check on imageView when setViewsBounds method is triggered.
